### PR TITLE
refactor: reduce description length default and max values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- Default approximate length of description reduced to 200 and max value of slider to 300 characters.
 - Deps: update `@angular` to 18.1.2.
 - Deps: update `openai` to 4.53.2.
 - Deps: update `tslib` to 2.6.3.

--- a/src/app/components/settings-form/settings-form.component.ts
+++ b/src/app/components/settings-form/settings-form.component.ts
@@ -26,7 +26,7 @@ import { Model } from '../../types/model.types';
   styleUrl: './settings-form.component.scss'
 })
 export class SettingsFormComponent {
-  descLengthMax: number = 350;
+  descLengthMax: number = 300;
   descLengthMin: number = 150;
   temperatureMax: number = 2.0;
   temperatureMin: number = 0.0;

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -17,7 +17,7 @@ export class SettingsService {
     prompts.map(p => ({ code: p.languageCode, name: p.languageDisplayName }))
   );
   private _promptTemplates = new BehaviorSubject<PromptOption[]>([]);
-  private _selectedDescLength = new BehaviorSubject<number>(250);
+  private _selectedDescLength = new BehaviorSubject<number>(200);
   private _selectedLanguage = new BehaviorSubject<string>('sv');
   private _selectedModel = new BehaviorSubject<Model|undefined>(
     models.filter((model) => model.default)[0]


### PR DESCRIPTION
Default value set to 200 and max value set to 300 characters.