### PR TITLE
feat: add `DOCX table` export format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - Support for OpenAI `gpt-4o-mini` model.
+- New export format: DOCX file with the data (image filenames and generated descriptions) structured as a table. This new format has been set as the default export format.
 
 ### Changed
 

--- a/src/app/components/generate-descriptions/generate-descriptions.component.html
+++ b/src/app/components/generate-descriptions/generate-descriptions.component.html
@@ -13,7 +13,8 @@
       <mat-form-field appearance="outline">
         <mat-label>Export format</mat-label>
         <mat-select [(ngModel)]="selectedExportFormat" name="exportFormat">
-          <mat-option value="docx">DOCX</mat-option>
+          <mat-option value="docx-table">DOCX (table)</mat-option>
+          <mat-option value="docx">DOCX (paragraphs)</mat-option>
           <mat-option value="tab">TAB</mat-option>
           <mat-option value="csv">CSV</mat-option>
         </mat-select>

--- a/src/app/components/generate-descriptions/generate-descriptions.component.ts
+++ b/src/app/components/generate-descriptions/generate-descriptions.component.ts
@@ -55,7 +55,7 @@ export class GenerateDescriptionsComponent implements AfterViewInit, OnInit {
   matTableDataSource = new MatTableDataSource<ImageData>([]);
   displayedColumns: string[] = ['imagePreview', 'description', 'actions'];
   generating: boolean = false;
-  selectedExportFormat: string = 'docx';
+  selectedExportFormat: string = 'docx-table';
   totalCost: number = 0;
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;


### PR DESCRIPTION
New export format: DOCX file with the data (image filenames and generated descriptions) structured as a table. This new format has been set as the default export format.