### PR TITLE
build: configure dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot version updates.
+# Documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Allow up to 10 open pull requests for npm dependencies
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(dev-deps)"
+    ignore:
+      # Do not update @angular dependencies at all; these are updated manually
+      - dependency-name: "@angular*"
+      # Do not update major versions
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- Configuration file for Dependabot version updates of packages.
+
 
 
 ## [1.1.0] – 2024-08-01


### PR DESCRIPTION
Dependabot can update minor and patch versions of all dependencies except `@angular` packages, which are updated manually.