### PR TITLE
feat: support `gemini-3.6-flash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Node `^22.22.3` or newer required.
 
+### Added
+
+- Support for the Google `gemini-3.6-flash` model. It replaces `gemini-3.5-flash`.
+- Model-config aware temperature support rules: the temperature setting is disabled/omitted when generally unsupported by the model.
+
 ### Changed
 
 - Migrate unit testing from Karma/Jasmine to Vitest.

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -34,7 +34,7 @@
           <h2>Model tips</h2>
           <ul>
             <li><strong>Alt text:</strong> GPT-4.1 or Gemini 2.5</li>
-            <li><strong>Printed text:</strong> Gemini 3.5 Flash</li>
+            <li><strong>Printed text:</strong> Gemini 3.6 Flash</li>
             <li><strong>Handwriting:</strong> Gemini 3.1 Pro</li>
             <li><strong>TEI-encoding:</strong> Gemini 3.1 Pro</li>
           </ul>

--- a/src/app/components/settings-form/settings-form.component.html
+++ b/src/app/components/settings-form/settings-form.component.html
@@ -258,6 +258,8 @@
               >
             </mat-slider>
           </div>
+        } @else if (model.parameters?.supportsTemperatureSampling === false) {
+          <p class="slider-support-message">This model does not support the temperature setting.</p>
         } @else {
           <p class="slider-support-message">This model does not support the temperature setting when {{ model.provider === 'OpenAI' ? 'reasoning' : 'thinking' }} is enabled.</p>
         }

--- a/src/app/services/google.service.spec.ts
+++ b/src/app/services/google.service.spec.ts
@@ -6,7 +6,7 @@ function createSettings(overrides: Partial<RequestSettings> = {}): RequestSettin
         model: {
             provider: 'Google',
             name: 'Test model',
-            id: 'gemini-3.5-flash',
+            id: 'gemini-3.1-pro-preview',
             inputPrice: 0,
             outputPrice: 0,
             rpm: 1,
@@ -79,6 +79,38 @@ describe('GoogleService', () => {
                     reasoningSupportsTemperature: false,
                 },
             },
+        }), 'Prompt', 'data:image/png;base64,AAAA');
+
+        const payload = vi.mocked(generateSpy).mock.lastCall![0];
+        expect('temperature' in payload.config).toBe(false);
+    });
+
+    it('omits temperature when the model does not support temperature sampling', async () => {
+        const service = new GoogleService();
+        const generateSpy = vi.fn().mockResolvedValue({
+            text: 'ok',
+            usageMetadata: {
+                promptTokenCount: 1,
+                candidatesTokenCount: 1,
+                thoughtsTokenCount: 0,
+            },
+        });
+
+        (service as any).client = {
+            models: {
+                generateContent: generateSpy,
+            },
+        };
+
+        await service.describeImage(createSettings({
+            model: {
+                ...createSettings().model,
+                id: 'gemini-3.6-flash',
+                parameters: {
+                    supportsTemperatureSampling: false,
+                },
+            },
+            thinkingLevel: null,
         }), 'Prompt', 'data:image/png;base64,AAAA');
 
         const payload = vi.mocked(generateSpy).mock.lastCall![0];

--- a/src/app/services/openai.service.spec.ts
+++ b/src/app/services/openai.service.spec.ts
@@ -100,6 +100,34 @@ describe('OpenAiService', () => {
         expect('temperature' in payload).toBe(false);
     });
 
+    it('omits temperature when the model does not support temperature sampling', async () => {
+        const service = new OpenAiService();
+        const createSpy = vi.fn().mockResolvedValue({
+            output_text: 'ok',
+            usage: { input_tokens: 1, output_tokens: 1 },
+        });
+
+        (service as any).client = {
+            responses: {
+                create: createSpy,
+            },
+        } as any;
+
+        await service.describeImage(createSettings({
+            model: {
+                ...createSettings().model,
+                parameters: {
+                    ...createSettings().model.parameters,
+                    supportsTemperatureSampling: false,
+                },
+            },
+            reasoningEffort: 'none',
+        }), 'Prompt', 'data:image/png;base64,AAAA');
+
+        const payload = vi.mocked(createSpy).mock.lastCall![0];
+        expect('temperature' in payload).toBe(false);
+    });
+
     it('uses image detail from the model parameters', async () => {
         const service = new OpenAiService();
         const createSpy = vi.fn().mockResolvedValue({

--- a/src/app/services/settings.service.spec.ts
+++ b/src/app/services/settings.service.spec.ts
@@ -26,4 +26,12 @@ describe('SettingsService', () => {
     service.updateSelectedTaskType('altText');
     expect(service.selectedTemperature()).toBe(0.4);
   });
+
+  it('reports temperature as unsupported for Gemini 3.6 Flash', () => {
+    const service = TestBed.inject(SettingsService);
+
+    service.updateSelectedModelId('gemini-3.6-flash');
+
+    expect(service.isTemperatureSupported()).toBe(false);
+  });
 });

--- a/src/app/types/model.types.ts
+++ b/src/app/types/model.types.ts
@@ -25,6 +25,9 @@ import type { ReasoningEffort } from 'openai/resources/shared';
 //                       `low`, `medium`, `high` and `xhigh` depending on model
 //     reasoningEfforts = (optional) selectable list of supported reasoning
 //                        effort values
+//     supportsTemperatureSampling = (optional) when false, temperature
+//                                   sampling is not supported;
+//                                   defaults to true if undefined
 //     reasoningSupportsTemperature = (optional) when false, temperature is
 //                                    only supported with provider-specific
 //                                    "no reasoning/thinking" settings;
@@ -66,6 +69,7 @@ export interface ModelParameters {
   mediaResolution?: string;
   reasoningEffort?: OpenAiReasoningEffort;
   reasoningEfforts?: OpenAiReasoningEffort[];
+  supportsTemperatureSampling?: boolean;
   reasoningSupportsTemperature?: boolean;
   thinkingLevel?: GeminiThinkingLevel;
   thinkingLevels?: GeminiThinkingLevel[];

--- a/src/app/utils/model-parameters.spec.ts
+++ b/src/app/utils/model-parameters.spec.ts
@@ -47,6 +47,24 @@ describe('isTemperatureSupportedForModel', () => {
         expect(isTemperatureSupportedForModel(settings.model, settings.reasoningEffort, settings.thinkingLevel)).toBe(true);
     });
 
+    it('gives the general temperature sampling opt-out precedence over reasoning support', () => {
+        const settings = createSettings({
+            model: {
+                ...createSettings().model,
+                id: 'gpt-5.4',
+                parameters: {
+                    supportsTemperatureSampling: false,
+                    reasoningSupportsTemperature: true,
+                    reasoningEffort: 'none',
+                    reasoningEfforts: ['none', 'low'],
+                },
+            },
+            reasoningEffort: 'none',
+        });
+
+        expect(isTemperatureSupportedForModel(settings.model, settings.reasoningEffort, settings.thinkingLevel)).toBe(false);
+    });
+
     it('requires OpenAI reasoning effort none when the flag is false', () => {
         const settings = createSettings({
             model: {
@@ -70,7 +88,7 @@ describe('isTemperatureSupportedForModel', () => {
             model: {
                 ...createSettings().model,
                 provider: 'Google',
-                id: 'gemini-3.5-flash',
+                id: 'gemini-3.1-pro-preview',
                 parameters: {
                     reasoningSupportsTemperature: false,
                     thinkingLevel: 'low',

--- a/src/app/utils/model-parameters.ts
+++ b/src/app/utils/model-parameters.ts
@@ -5,6 +5,10 @@ export function isTemperatureSupportedForModel(
   reasoningEffort?: OpenAiReasoningEffort | null,
   thinkingLevel?: GeminiThinkingLevel | null
 ): boolean {
+  if (!(model.parameters?.supportsTemperatureSampling ?? true)) {
+    return false;
+  }
+
   if (model.parameters?.reasoningSupportsTemperature ?? true) {
     return true;
   }

--- a/src/assets/config/models.ts
+++ b/src/assets/config/models.ts
@@ -2,7 +2,7 @@ import { Model } from '../../app/types/model.types'
 import { TaskTypeId } from './prompts';
 
 export type ModelProvider = 'OpenAI' | 'Google';
-export type ModelId = 'gpt-4.1' | 'gpt-5.4' | 'gpt-5.5' | 'gemini-3.1-pro-preview' | 'gemini-3.5-flash' | 'gemini-2.5-pro' | 'gemini-2.5-flash';
+export type ModelId = 'gpt-4.1' | 'gpt-5.4' | 'gpt-5.5' | 'gemini-3.1-pro-preview' | 'gemini-3.6-flash' | 'gemini-2.5-pro' | 'gemini-2.5-flash';
 
 // provider = name of model creator
 // name = display name of the model
@@ -25,6 +25,9 @@ export type ModelId = 'gpt-4.1' | 'gpt-5.4' | 'gpt-5.5' | 'gemini-3.1-pro-previe
 //                       `low`, `medium`, `high` and `xhigh` depending on model
 //     reasoningEfforts = (optional) selectable list of supported reasoning
 //                        effort values
+//     supportsTemperatureSampling = (optional) when false, temperature
+//                                   sampling is not supported;
+//                                   defaults to true if undefined
 //     reasoningSupportsTemperature = (optional) when false, temperature is
 //                                    only supported with provider-specific
 //                                    "no reasoning/thinking" settings;
@@ -91,19 +94,20 @@ export const MODELS: Model[] = [
   },
   {
     provider: 'Google',
-    name: 'Gemini 3.5 Flash',
-    id: 'gemini-3.5-flash',
+    name: 'Gemini 3.6 Flash',
+    id: 'gemini-3.6-flash',
     description: 'A fast and cost-efficient alternative to Gemini 3.1 Pro that delivers near-pro transcription quality, including handwritten text, with much higher throughput.',
     inputPrice: 1.5,
-    outputPrice: 9.0,
+    outputPrice: 7.5,
     rpm: 1000,
     supportedTaskTypes: ['altText', 'transcription', 'transcriptionBatchTei'],
-    url: 'https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash',
+    url: 'https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash',
     parameters: {
       thinkingLevel: 'low',
       thinkingLevels: ['minimal', 'low', 'medium', 'high'],
       maxImageShortsidePx: null,
-      mediaResolution: 'high'
+      mediaResolution: 'high',
+      supportsTemperatureSampling: false
     },
     supportsFilesApi: true
   },


### PR DESCRIPTION
Replaces `gemini-3.5-flash`. Also adds a model option to disable the temperature setting if the model does not support temperature sampling.