### PR TITLE
feat: support `gpt-5.6-terra` and `gpt-5.6-sol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- Support for the Google `gemini-3.6-flash` model. It replaces `gemini-3.5-flash`.
+- Support for the Google [`gemini-3.6-flash`](https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash) model. It replaces `gemini-3.5-flash`.
+- Support for the OpenAI [`gpt-5.6-terra`](https://developers.openai.com/api/docs/models/gpt-5.6-terra) and [`gpt-5.6-sol`](https://developers.openai.com/api/docs/models/gpt-5.6-sol) models. They replace `gpt-5.4` and `gpt-5.5` respectively.
 - Model-config aware temperature support rules: the temperature setting is disabled/omitted when generally unsupported by the model.
 
 ### Changed

--- a/src/app/services/openai.service.spec.ts
+++ b/src/app/services/openai.service.spec.ts
@@ -7,7 +7,7 @@ function createSettings(overrides: Partial<RequestSettings> = {}): RequestSettin
         model: {
             provider: 'OpenAI',
             name: 'Test model',
-            id: 'gpt-5.4',
+            id: 'gpt-5.6-terra',
             inputPrice: 0,
             outputPrice: 0,
             rpm: 1,

--- a/src/app/utils/model-parameters.spec.ts
+++ b/src/app/utils/model-parameters.spec.ts
@@ -35,7 +35,7 @@ describe('isTemperatureSupportedForModel', () => {
         const settings = createSettings({
             model: {
                 ...createSettings().model,
-                id: 'gpt-5.4',
+                id: 'gpt-5.6-terra',
                 parameters: {
                     reasoningEffort: 'none',
                     reasoningEfforts: ['none', 'low'],
@@ -51,7 +51,7 @@ describe('isTemperatureSupportedForModel', () => {
         const settings = createSettings({
             model: {
                 ...createSettings().model,
-                id: 'gpt-5.4',
+                id: 'gpt-5.6-terra',
                 parameters: {
                     supportsTemperatureSampling: false,
                     reasoningSupportsTemperature: true,
@@ -69,7 +69,7 @@ describe('isTemperatureSupportedForModel', () => {
         const settings = createSettings({
             model: {
                 ...createSettings().model,
-                id: 'gpt-5.4',
+                id: 'gpt-5.6-terra',
                 parameters: {
                     reasoningSupportsTemperature: false,
                     reasoningEffort: 'none',

--- a/src/assets/config/models.ts
+++ b/src/assets/config/models.ts
@@ -2,7 +2,7 @@ import { Model } from '../../app/types/model.types'
 import { TaskTypeId } from './prompts';
 
 export type ModelProvider = 'OpenAI' | 'Google';
-export type ModelId = 'gpt-4.1' | 'gpt-5.4' | 'gpt-5.5' | 'gemini-3.1-pro-preview' | 'gemini-3.6-flash' | 'gemini-2.5-pro' | 'gemini-2.5-flash';
+export type ModelId = 'gpt-4.1' | 'gpt-5.6-terra' | 'gpt-5.6-sol' | 'gemini-3.1-pro-preview' | 'gemini-3.6-flash' | 'gemini-2.5-pro' | 'gemini-2.5-flash';
 
 // provider = name of model creator
 // name = display name of the model
@@ -56,14 +56,14 @@ export const MODELS: Model[] = [
   },
   {
     provider: 'OpenAI',
-    name: 'GPT-5.4',
-    id: 'gpt-5.4',
-    description: 'A powerful model optimized for high-quality outputs, well suited for complex images.',
-    inputPrice: { tiers: [{ upToTokens: 272000, per1M: 2.50 }, { upToTokens: null, per1M: 5.00 }] },
-    outputPrice: { tiers: [{ upToTokens: 272000, per1M: 15.00 }, { upToTokens: null, per1M: 22.50 }] },
+    name: 'GPT-5.6 Terra',
+    id: 'gpt-5.6-terra',
+    description: 'A cost-conscious model that balances quality and price for alt text and complex image understanding.',
+    inputPrice: { tiers: [{ upToTokens: 272000, per1M: 2.00 }, { upToTokens: null, per1M: 4.00 }] },
+    outputPrice: { tiers: [{ upToTokens: 272000, per1M: 12.00 }, { upToTokens: null, per1M: 18.00 }] },
     rpm: 5000,
     supportedTaskTypes: ['altText', 'transcription', 'transcriptionBatchTei'],
-    url: 'https://developers.openai.com/api/docs/models/gpt-5.4',
+    url: 'https://developers.openai.com/api/docs/models/gpt-5.6-terra',
     parameters: {
       imageDetail: 'original',
       maxImageShortsidePx: null,
@@ -75,14 +75,14 @@ export const MODELS: Model[] = [
   },
   {
     provider: 'OpenAI',
-    name: 'GPT-5.5',
-    id: 'gpt-5.5',
-    description: 'A powerful model optimized for high-quality outputs, well suited for complex images.',
+    name: 'GPT-5.6 Sol',
+    id: 'gpt-5.6-sol',
+    description: 'The flagship GPT-5.6 model for high-quality alt text and complex image understanding.',
     inputPrice: { tiers: [{ upToTokens: 272000, per1M: 5.00 }, { upToTokens: null, per1M: 10.00 }] },
     outputPrice: { tiers: [{ upToTokens: 272000, per1M: 30.00 }, { upToTokens: null, per1M: 45.00 }] },
     rpm: 5000,
     supportedTaskTypes: ['altText', 'transcription', 'transcriptionBatchTei'],
-    url: 'https://developers.openai.com/api/docs/models/gpt-5.5',
+    url: 'https://developers.openai.com/api/docs/models/gpt-5.6-sol',
     parameters: {
       imageDetail: 'original',
       maxImageShortsidePx: null,


### PR DESCRIPTION
They replace `gpt-5.4` and `gpt-5.5` respectively.